### PR TITLE
UX: position indicator at the end of info to prevent height change

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,0 +1,7 @@
+aside.onebox .onebox-body .github-status-indicator {
+  height: $line-height-large * 1em;
+  width: 3 * $line-height-large * 1em;
+  object-fit: contain;
+  object-position: left;
+  margin: 0;
+}

--- a/javascripts/discourse/initializers/initialize-github-status.js.es6
+++ b/javascripts/discourse/initializers/initialize-github-status.js.es6
@@ -1,29 +1,43 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 export default {
   name: "my-initializer",
-  initialize(){
+  initialize() {
     withPluginApi("0.8.7", api => {
-        api.decorateCooked(
-               $elem => {
-                   const element = $elem[0];
-                   const oneboxes = element.querySelectorAll(".onebox.githubpullrequest, .onebox.githubissue");
-                   oneboxes.forEach(onebox => {
-                       const link = onebox.querySelector(".source a")
-                       if(!link) return;
-                       const href = link.getAttribute("href");
-                       const parts = href.match(/https:\/\/github\.com\/(\w+)\/(\w+)\/(pull|issues)\/(\d+)/);
-                       if(!parts) return;
-                       var linkType = parts[3];
-                       if(linkType==="pull") linkType = "pulls";
-                       const imageSrc = `https://img.shields.io/github/${linkType}/detail/state/${parts[1]}/${parts[2]}/${parts[4]}?label=&style=flat-square`
-                       const image = document.createElement("img")
-                       image.setAttribute("src", imageSrc);
-                       image.setAttribute("style", "display: inline; float: none; height: 1em;")
-                       onebox.querySelector("h4").appendChild(image);
-                   })
-               },
-               { id: 'github-status' }
-        );
+      api.decorateCooked(
+        $elem => {
+          const element = $elem[0];
+          const oneboxes = element.querySelectorAll(
+            ".onebox.githubpullrequest, .onebox.githubissue"
+          );
+          oneboxes.forEach(onebox => {
+            const link = onebox.querySelector(".source a");
+            if (!link) return;
+
+            const href = link.getAttribute("href");
+            const parts = href.match(
+              /https:\/\/github\.com\/(\w+)\/(\w+)\/(pull|issues)\/(\d+)/
+            );
+            if (!parts) return;
+
+            let linkType = parts[3];
+            if (linkType === "pull") linkType = "pulls";
+
+            const imageSrc = `https://img.shields.io/github/${linkType}/detail/state/${
+              parts[1]
+            }/${parts[2]}/${parts[4]}?label=&style=flat-square`;
+            const image = document.createElement("img");
+            image.setAttribute("src", imageSrc);
+            image.setAttribute(
+              "style",
+              "display: inline-block; float: none; max-width: 100%; max-height: 100%;"
+            );
+
+            const info = element.querySelector(".github-info");
+            info.appendChild(image);
+          });
+        },
+        { id: "github-status" }
+      );
     });
   }
-}
+};

--- a/javascripts/discourse/initializers/initialize-github-status.js.es6
+++ b/javascripts/discourse/initializers/initialize-github-status.js.es6
@@ -27,10 +27,7 @@ export default {
             }/${parts[2]}/${parts[4]}?label=&style=flat-square`;
             const image = document.createElement("img");
             image.setAttribute("src", imageSrc);
-            image.setAttribute(
-              "style",
-              "display: inline-block; float: none; max-width: 100%; max-height: 100%;"
-            );
+            image.classList.add("github-status-indicator");
 
             const info = onebox.querySelector(".github-info");
             info.appendChild(image);
@@ -39,5 +36,5 @@ export default {
         { id: "github-status" }
       );
     });
-  }
+  },
 };

--- a/javascripts/discourse/initializers/initialize-github-status.js.es6
+++ b/javascripts/discourse/initializers/initialize-github-status.js.es6
@@ -32,7 +32,7 @@ export default {
               "display: inline-block; float: none; max-width: 100%; max-height: 100%;"
             );
 
-            const info = element.querySelector(".github-info");
+            const info = onebox.querySelector(".github-info");
             info.appendChild(image);
           });
         },


### PR DESCRIPTION
Height change would happen if commit title was barely at the screen width, appending the indicator later would make it go on a second line.